### PR TITLE
Enhance CoS tower defense gameplay

### DIFF
--- a/app/CoS/page.js
+++ b/app/CoS/page.js
@@ -10,13 +10,18 @@ import { motion } from 'framer-motion'
  *************************************/
 
 /*************** CONSTANTS ****************/
-const LANES = { ground: 120, air: 40 }
+const LANES = { ground: 130, air: 50 }
 const TICK = 60 // ms
 const ARENA_WIDTH = 900
 const PLAYER_BASE_X = 50
 const ENEMY_BASE_X = ARENA_WIDTH - 50
 const DEFAULT_RANGE = 120
 const PUB_MAX_HP = 500
+
+const WAVE_DURATION = 30000 // 30s per wave
+const BTC_PASSIVE_RATE = 10 // per second
+const ENEMY_HP_SCALE = 0.8
+const ENEMY_DMG_SCALE = 0.8
 
 const speedToDx = (s) => (s === 'slow' ? 20 : s === 'fast' ? 80 : 40)
 
@@ -30,27 +35,30 @@ const PLAYER_UNITS = {
 
 /*************** ENEMIES ****************/
 function enemyTemplate(type) {
-  switch (type) {
-    case 'lewak':
-      return { id: 'lewak-' + Math.random(), label: 'Pojedynczy lewak', lane: 'ground', hp: 15,  dmg: 2.5, speedName: 'normal', x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 25 }
-    case 'zandberg':
-      return { id: 'zand-' + Math.random(),  label: 'Zandberg',         lane: 'ground', hp: 75,  dmg: 22,  speedName: 'slow',   x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 125 }
-    case 'trzaskAir':
-      return { id: 'trz-' + Math.random(),   label: 'Samolot Trzaskowskiego', lane: 'air', hp: 30,  dmg: 10,  speedName: 'fast',   x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 60 }
-    case 'tusk':
-      return { id: 'tusk-' + Math.random(),  label: 'Niemiecki Batalion Tuska', lane: 'ground', hp: 200, dmg: 2.5, speedName: 'slow',   x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 200 }
-    case 'senyszynBoss':
-    default:
-      return { id: 'senyszyn', label: 'Wielka Senyszyn', lane: 'both', hp: 500, dmg: 25, speedName: 'slow', x: ENEMY_BASE_X, range: DEFAULT_RANGE + 40, bounty: 500 }
-  }
+  const base = (() => {
+    switch (type) {
+      case 'lewak':
+        return { id: 'lewak-' + Math.random(), label: 'Pojedynczy lewak', lane: 'ground', hp: 15, dmg: 2.5, speedName: 'normal', x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 25, color: '#ff3333' };
+      case 'zandberg':
+        return { id: 'zand-' + Math.random(), label: 'Zandberg', lane: 'ground', hp: 75, dmg: 22, speedName: 'slow', x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 125, color: '#ff6666' };
+      case 'trzaskAir':
+        return { id: 'trz-' + Math.random(), label: 'Samolot Trzaskowskiego', lane: 'air', hp: 30, dmg: 10, speedName: 'fast', x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 60, color: '#ffcc00' };
+      case 'tusk':
+        return { id: 'tusk-' + Math.random(), label: 'Niemiecki Batalion Tuska', lane: 'ground', hp: 200, dmg: 2.5, speedName: 'slow', x: ENEMY_BASE_X, range: DEFAULT_RANGE, bounty: 200, color: '#ff0000' };
+      case 'senyszynBoss':
+      default:
+        return { id: 'senyszyn', label: 'Wielka Senyszyn', lane: 'both', hp: 500, dmg: 25, speedName: 'slow', x: ENEMY_BASE_X, range: DEFAULT_RANGE + 40, bounty: 500, color: '#ff8800' };
+    }
+  })();
+  return { ...base, hp: base.hp * ENEMY_HP_SCALE, dmg: base.dmg * ENEMY_DMG_SCALE };
 }
-
 function generateWave(count) {
   const types = ['lewak', 'trzaskAir', 'zandberg', 'tusk']
   const arr = []
   for (let i = 0; i < count; i++) {
     const type = types[Math.floor(Math.random() * types.length)]
-    arr.push({ ...enemyTemplate(type), spawnDelay: i * 600 })
+    const delay = Math.floor((i * WAVE_DURATION) / count)
+    arr.push({ ...enemyTemplate(type), spawnDelay: delay })
   }
   return arr
 }
@@ -79,6 +87,7 @@ export default function Home() {
   const [players, setPlayers]       = useState([])
   const [pubHp, setPubHp]           = useState(PUB_MAX_HP)
   const [tickTime, setTickTime]     = useState(Date.now())
+  const [pendingSpawns, setPendingSpawns] = useState([])
   const intervalRef                 = useRef(null)
 
   /* ---------- GAME LOOP TIMER ---------- */
@@ -87,13 +96,32 @@ export default function Home() {
     return () => clearInterval(intervalRef.current)
   }, [])
 
+  // passive BTC gain
+  useEffect(() => {
+    const id = setInterval(() => setBtc(b => b + BTC_PASSIVE_RATE), 1000)
+    return () => clearInterval(id)
+  }, [])
+
   /* ---------- SPAWN NEXT WAVE ---------- */
   useEffect(() => {
-    if (enemies.length === 0 && waveIdx < ENEMY_WAVES.length) {
-      setEnemies(ENEMY_WAVES[waveIdx]())
+    if (enemies.length === 0 && pendingSpawns.length === 0 && waveIdx < ENEMY_WAVES.length) {
+      const now = Date.now()
+      const wave = ENEMY_WAVES[waveIdx]().map(e => ({ ...e, spawnAt: now + e.spawnDelay }))
+      setPendingSpawns(wave)
       setWaveIdx(waveIdx + 1)
     }
-  }, [enemies, waveIdx])
+  }, [enemies, pendingSpawns, waveIdx])
+
+  // spawn queued enemies
+  useEffect(() => {
+    if (pendingSpawns.length === 0) return
+    const now = Date.now()
+    const toSpawn = pendingSpawns.filter(e => e.spawnAt <= now)
+    if (toSpawn.length) {
+      setEnemies(prev => [...prev, ...toSpawn])
+      setPendingSpawns(pendingSpawns.filter(e => e.spawnAt > now))
+    }
+  }, [tickTime, pendingSpawns])
 
   /* ---------- MAIN TICK ---------- */
   useEffect(() => {
@@ -219,7 +247,7 @@ export default function Home() {
         style={{
           position: 'relative',
           width: ARENA_WIDTH,
-          height: 160,
+          height: 180,
           margin: '100px auto',
           background: '#060',
           border: '4px solid #333',
@@ -240,11 +268,11 @@ export default function Home() {
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            fontSize: 10
+            fontSize: 14
           }}
         >
           <div>PUB</div>
-          <div style={{ fontSize: 9 }}>HP: {pubHp}</div>
+          <div style={{ fontSize: 12 }}>HP: {pubHp}</div>
         </div>
 
         {/* UNITS */}
@@ -258,10 +286,10 @@ export default function Home() {
               left: 0,
               top: LANES[u.lane] || 0,
               transform: `translateX(${u.x}px)`,
-              background: u.label.includes('lewak') ? '#f55' : '#fff',
+              background: u.color || (u.label.includes('lewak') ? '#f55' : '#fff'),
               color: '#000',
-              padding: '2px 4px',
-              fontSize: 10,
+              padding: '4px 6px',
+              fontSize: 14,
               borderRadius: 3
             }}
           >
@@ -270,7 +298,7 @@ export default function Home() {
         ))}
 
         {/* Wave counter */}
-        <div style={{ position: 'absolute', right: 10, bottom: 5, fontSize: 10, color: '#fff' }}>
+        <div style={{ position: 'absolute', right: 10, bottom: 5, fontSize: 12, color: '#fff' }}>
           Fala: {Math.min(waveIdx, 10)} / 10
         </div>
       </div>


### PR DESCRIPTION
## Summary
- enlarge lanes and unit visuals
- color-code enemy units and scale their stats
- generate enemy waves over time
- grant passive BTC income
- increase arena height and enlarge UI text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684abac1407083238f9efc8713d23bfa